### PR TITLE
adding param_vis 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -586,6 +586,9 @@ export default {
     if (this.$route.query.auth_token) {
       this.$store.dispatch('setAuthToken', this.$route.query.auth_token);
     }
+    if (this.$route.query.param_vis) {
+      this.$store.dispatch('setParamVis', this.$route.query.param_vis);
+    }
     if (!_.isEmpty(this.$route.query)) {
         this.$store.dispatch('setQueryParameters', this.$route.query);
     }

--- a/src/components/Survey/Survey.vue
+++ b/src/components/Survey/Survey.vue
@@ -398,6 +398,11 @@
             if (_.isString(val)) {
               val = this.evaluateString(val, responseMapper);
             }
+            // if a number is provided, we compare to the param_vis
+            else if (_.isNumber(val)) {
+              if (val == this.$store.getters.getParamVis) val = true
+              else val = false
+            }
             if (responseMapper[a['http://schema.repronim.org/variableName'][0]['@value']]) {
               visibilityMapper[responseMapper[a['http://schema.repronim.org/variableName'][0]['@value']].ref] = val;
             }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -78,6 +78,10 @@ const getters = {
     return state.token;
   },
   // eslint-disable-next-line
+  getParamVis(state) {
+    return state.param_vis;
+  },
+  // eslint-disable-next-line
   getHasExport(state) {
     return state.hasExport;
   },
@@ -131,6 +135,10 @@ const mutations = {
   // eslint-disable-next-line
   setAuthToken(state, authToken) {
     state.token = authToken;
+  },
+  // eslint-disable-next-line
+  setParamVis(state, param_vis) {
+    state.param_vis = param_vis;
   },
   // eslint-disable-next-line
   setParticipantUUID(state, uid) {
@@ -247,6 +255,9 @@ const actions = {
   },
   setAuthToken({ commit }, tok) {
     commit('setAuthToken', tok);
+  },
+  setParamVis({ commit }, tok) {
+    commit('setParamVis', tok);
   },
   setExpiryMinutes({ commit }, mins) {
     commit('setExpiryMinutes', mins);


### PR DESCRIPTION
`param_vis` could be added to the URL and if an integer is used in protocol to set `isVis`, e.g if `"isVis": 3` the activity will be show only if URL will have `?param_vis=3`

This could be tested with the new branch od depo: https://github.com/ReproNim/demo-protocol/pull/19