### PR TITLE
fix: post if server is not null and token available

### DIFF
--- a/src/components/Inputs/SaveData/SaveData.vue
+++ b/src/components/Inputs/SaveData/SaveData.vue
@@ -197,7 +197,7 @@ export default {
     sendRetry(url, formData, index, retries = 3, backoff = 10000) {
         if (!this.shouldUpload) {
           console.log("Not uploading")
-          return;
+          return 200;
         }
         const config1 = {
         'Content-Type': 'multipart/form-data'

--- a/src/components/Inputs/SaveData/SaveData.vue
+++ b/src/components/Inputs/SaveData/SaveData.vue
@@ -195,10 +195,14 @@ export default {
         });
     },
     sendRetry(url, formData, index, retries = 3, backoff = 10000) {
+        if (!this.shouldUpload) {
+          console.log("Not uploading")
+          return;
+        }
         const config1 = {
         'Content-Type': 'multipart/form-data'
         };
-        return axios.post(`${config.backendServer}/submit`, formData, config1).then((res) => {
+        return axios.post(url, formData, config1).then((res) => {
           // console.log(322, 'SUCCESS!!', `${fileName}.zip.00${index}`, res.status);
           slicedArray.splice(index, 1); // remove successfully POSTed slice
           sentPartCount++;

--- a/src/components/Survey/Survey.vue
+++ b/src/components/Survey/Survey.vue
@@ -490,12 +490,16 @@
           });
       },
       async sendRetry(url, formData, retries = 3, backoff = 10000) {
+        if (!this.shouldUpload) {
+          console.log("Not uploading")
+          return;
+        }
         const config1 = {
           'Content-Type': 'multipart/form-data'
         };
         try {
           // eslint-disable-next-line no-unused-vars
-          const res = await axios.post(`${config.backendServer}/submit`, formData, config1);
+          const res = await axios.post(url, formData, config1);
           // console.log(530, 'SUCCESS!!', formData, res.status);
         } catch (e) {
           if (retries > 0) {
@@ -581,6 +585,9 @@
           // console.log(495, criteria1, criteria2);
           return criteria1 && criteria2;
         });
+      },
+      shouldUpload() {
+        return !!(config.backendServer && this.$store.getters.getAuthToken);
       },
       context() {
         /* eslint-disable */


### PR DESCRIPTION
the current `sendRetry` code will post to a url that is not configured as a server or has no auth token. this PR prevents any data submission without access to a backend server and an auth tooken.